### PR TITLE
40/Disable ESLint blocking during build on Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,9 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   /* config options here */
   reactStrictMode: true,
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
### 🔧What does this PR do?

This PR disables ESLint blocking during the Vercel build process by updating the `next.config.ts` file.

###  Changes Made

- Added `eslint: { ignoreDuringBuilds: true }` to `next.config.ts` to allow the project to build even when there are ESLint errors.

###  Why is this needed?

Currently, the build fails on Vercel due to numerous ESLint errors (e.g., use of `any`, empty object types).  
This change unblocks the deployment process while allowing developers to fix linting issues incrementally.

###  Related Issue

Closes #40 
