### PR TITLE
44/Add GitHub Action for Discord notifications on issues and PR merges

### DIFF
--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -1,0 +1,87 @@
+name: Notify Discord on Issues and PR Merges
+
+on:
+  issues:
+    types: [opened, labeled]
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [opened, closed, labeled]
+  pull_request_review:
+    types: [submitted]
+  push:
+    branches:
+      - main
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send notification to Discord
+        uses: dawidd6/action-discord@v3
+        with:
+          webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          message: |
+            ${{ 
+              github.event_name == 'issues' && 
+              format('🆕 Issue #{0}: {1}\nBy: {2}\n{3}', 
+                github.event.issue.number, 
+                github.event.issue.title, 
+                github.event.issue.user.login,
+                github.event.issue.html_url) 
+            }}
+
+            ${{ 
+              github.event_name == 'issue_comment' && 
+              format('💬 New comment on Issue #{0} by {1}:\n{2}\n{3}', 
+                github.event.issue.number,
+                github.event.comment.user.login,
+                github.event.comment.body,
+                github.event.issue.html_url)
+            }}
+
+            ${{ 
+              github.event_name == 'pull_request' && 
+              github.event.action == 'opened' &&
+              format('🚀 PR Opened #{0}: {1}\nBy: {2}\n{3}', 
+                github.event.pull_request.number,
+                github.event.pull_request.title,
+                github.event.pull_request.user.login,
+                github.event.pull_request.html_url)
+            }}
+
+            ${{ 
+              github.event_name == 'pull_request' && 
+              github.event.action == 'closed' && 
+              github.event.pull_request.merged &&
+              format('✅ PR Merged #{0}: {1}\nBy: {2}\n{3}', 
+                github.event.pull_request.number,
+                github.event.pull_request.title,
+                github.event.pull_request.merged_by.login,
+                github.event.pull_request.html_url)
+            }}
+
+            ${{ 
+              github.event_name == 'pull_request_review' &&
+              format('🔍 PR Review on #{0} by {1}:\nState: {2}\n{3}', 
+                github.event.pull_request.number,
+                github.event.review.user.login,
+                github.event.review.state,
+                github.event.pull_request.html_url)
+            }}
+
+            ${{ 
+              github.event_name == 'push' && 
+              format('📌 New push to {0} by {1}\nCommit message: {2}', 
+                github.ref,
+                github.actor,
+                github.event.head_commit.message)
+            }}
+
+            ${{ 
+              github.event_name == 'release' && 
+              format('🏷️ New release published: {0} by {1}\n{2}', 
+                github.event.release.tag_name,
+                github.event.release.author.login,
+                github.event.release.html_url)
+            }}


### PR DESCRIPTION
### What does this PR do?
This PR adds Discord notifications GitHub Action workflow.

### Changes Made
Added ```github/workflows/discord-notify.yml```

### Related Issue
Closes https://github.com/HelpChainUA/helpchain-ua/issues/44