### PR TITLE
54/Fix: add request arg to authorize + prisma generate to postinstall fo…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
+    "build": "next build",                  
+    "postinstall": "prisma generate",
     "start": "next start",
     "lint": "next lint"
   },

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -20,7 +20,7 @@ export const authOptions: NextAuthOptions = {
         email: { label: "Email", type: "text" },
         password: { label: "Password", type: "password" },
       },
-      async authorize(credentials) {
+      async authorize(credentials, request) {
         if (!credentials?.email || !credentials?.password) return null;
 
         const user = await prisma.user.findUnique({


### PR DESCRIPTION
### Description 
This PR relates to issue 54 and it fixes issues for backend deployment. 
It ensures the correct Prisma client generation during the build process and updates the authentication configuration to handle request parameters properly. 

### Changes Made

- Added ```postinstall``` script to package.json to run ```prisma generate``` automatically after dependencies install.
- Modified NextAuth ```authorize``` function to accept the ```request``` argument as required by the latest type definitions.
- Verified build and deployment processes to ensure Prisma client is up-to-date and authentication works correctly.

### Why is this needed?

- Vercel caches dependencies which can cause Prisma Client to be outdated if prisma generate is not run during build, leading to runtime errors.
- NextAuth’s authorize method signature changed, so the request parameter must be included to avoid type errors and potential runtime issues.
- These fixes are necessary to prevent build failures and authentication errors in production deployments.