### PR TITLE
feat(auth): add email validation to auth pages using validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "uuid": "^11.1.0",
+        "validator": "^13.15.15",
         "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
@@ -38,6 +39,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/uuid": "^10.0.0",
+        "@types/validator": "^13.15.2",
         "@types/zxcvbn": "^4.4.5",
         "@vitest/browser": "^3.2.4",
         "@vitest/coverage-v8": "^3.2.4",
@@ -3504,6 +3506,13 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.2",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.2.tgz",
+      "integrity": "sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -10272,6 +10281,15 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "uuid": "^11.1.0",
+    "validator": "^13.15.15",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
@@ -44,6 +45,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/uuid": "^10.0.0",
+    "@types/validator": "^13.15.2",
     "@types/zxcvbn": "^4.4.5",
     "@vitest/browser": "^3.2.4",
     "@vitest/coverage-v8": "^3.2.4",

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,6 +1,8 @@
 import { prisma } from "@/lib/prisma";
 import bcrypt from "bcrypt";
 import { NextResponse } from "next/server";
+import validator from "validator";
+import { isPasswordValid } from "@/utils/validatePassword";
 
 export async function POST(req: Request) {
   const { email, password } = await req.json();
@@ -21,17 +23,15 @@ export async function POST(req: Request) {
     );
   }
 
-  const isPasswordValid = (password: string) => {
-    const strongRegex =
-      /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_])[A-Za-z\d\W_]{8,128}$/;
-    return strongRegex.test(password);
-  };
-
   if (!isPasswordValid(password)) {
     return NextResponse.json(
       { message: "Password does not meet complexity requirements." },
       { status: 400 }
     );
+  }
+
+  if (!validator.isEmail(email)) {
+  return NextResponse.json({ message: "Invalid email format" }, { status: 400 });
   }
 
   const hashedPassword = await bcrypt.hash(password, 10);

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -3,6 +3,8 @@
 
 import { useState } from "react";
 import axios from "axios";
+import validator from "validator";
+import TextInput from "@/components/ui/TextInput";
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState("");
@@ -15,6 +17,11 @@ export default function ForgotPasswordPage() {
 
     if (!email) {
       setError("Please enter your email address.");
+      return;
+    }
+
+    if (!validator.isEmail(email)) {
+      setError("Invalid email format.");
       return;
     }
 
@@ -55,7 +62,11 @@ export default function ForgotPasswordPage() {
         </p>
       </div>
 
-      <form onSubmit={handleSubmit} className="flex flex-col gap-6 w-full max-w-xl">
+      <form
+        noValidate
+        onSubmit={handleSubmit}
+        className="flex flex-col gap-6 w-full max-w-xl"
+      >
         {error && (
           <p className="rounded-md bg-red-100 p-2 text-center text-red-700">
             {error}
@@ -63,15 +74,14 @@ export default function ForgotPasswordPage() {
         )}
 
         <div className="flex flex-col gap-1.5">
-          <label className="font-karla font-normal text-base text-gray-700">
-            Email
-          </label>
-          <input
+          {/* Email input field*/}
+          <TextInput
+            label="Email"
             type="email"
-            required
             value={email}
+            required
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 bg-white focus:outline-none focus:ring-3 focus:ring-primary-100 focus:shadow-input"
+            helperText="Enter your email."
           />
         </div>
 

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -4,6 +4,7 @@ import { signIn } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useState, Suspense } from "react";
 import Link from "next/link";
+import validator from "validator";
 import { EyeOn, EyeOff } from "@/icons/index";
 import SocialAuthButtons from "@/components/SocialAuthButtons";
 import TextInput from "@/components/ui/TextInput";
@@ -36,6 +37,15 @@ export default function SignInPage() {
 
     if (!email || !password) {
       setError("Please fill in all required fields.");
+      return;
+    }
+
+    if (!validator.isEmail(email)) {
+      return;
+    }
+
+    if (!password) {
+      // setError("Please enter your password.");
       return;
     }
 
@@ -94,6 +104,8 @@ export default function SignInPage() {
           error={
             emailTouched && !email && !emailFocused
               ? "Required field." // shows error only when blurred and empty
+              : emailTouched && email && !validator.isEmail(email) && !emailFocused
+              ? "Invalid email format."
               : undefined
           }
         />

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,9 +3,10 @@
 import { useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import validator from "validator";
 import { EyeOn, EyeOff, CheckMark } from "@/icons/index";
 import SocialAuthButtons from "@/components/SocialAuthButtons";
-import { validatePassword } from "@/utils/validatePassword";
+import { isPasswordValid, validatePassword } from "@/utils/validatePassword";
 import TextInput from "@/components/ui/TextInput";
 
 export default function RegisterPage() {
@@ -50,13 +51,16 @@ export default function RegisterPage() {
       return;
     }
 
+    if (!validator.isEmail(email) || !isPasswordValid(password)) {
+      return;
+    }
+
     if (passwordError) {
       setError(passwordError);
       return;
     }
 
     if (passwordConfirmed !== password) {
-      setError("Passwords don't match.");
       return;
     }
 
@@ -69,7 +73,7 @@ export default function RegisterPage() {
     if (res.status === 201) {
       router.push("/signin");
     } else {
-      const data = await res.json();
+      const data = await res.json();  // Error comes from backend route
       setError(data.message || "Something went wrong");
     }
   };
@@ -121,6 +125,8 @@ export default function RegisterPage() {
             error={
               emailTouched && !email && !emailFocused
                 ? "Required field." // shows error only when blurred and empty
+                : emailTouched && email && !validator.isEmail(email) && !emailFocused
+                ? "Invalid email format."
                 : undefined
             }
           />

--- a/src/utils/validatePassword.ts
+++ b/src/utils/validatePassword.ts
@@ -34,3 +34,9 @@ export function validatePassword(password: string): string | null {
 
   return null;
 }
+
+export function isPasswordValid(password: string): boolean {
+  const strongRegex =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[\W_])[A-Za-z\d\W_]{8,128}$/;
+  return strongRegex.test(password);
+}


### PR DESCRIPTION
### Description:
This PR adds validation logic to the email input in auth using validator library. 

### Changes made:
- installed `validator`;
- updated register route to include email validation;
- updated forgot-password page to include email validation on submit and used a reusable `TextInput` component instead;
- updated signup page to include email validation;
- extracted `isPasswordValid` into utils;

### Screenshots:
<img width="844" height="863" alt="Screenshot 2025-08-07 at 08 43 31" src="https://github.com/user-attachments/assets/b4e2e3f1-86f8-422e-b50d-2c03a3d3d940" />
<img width="837" height="825" alt="Screenshot 2025-08-07 at 08 42 42" src="https://github.com/user-attachments/assets/40b0a9f4-f9ea-4518-bd61-a2b695ed7c1a" />
<img width="852" height="854" alt="Screenshot 2025-08-07 at 08 42 20" src="https://github.com/user-attachments/assets/2acc78bb-2505-4f5d-8fb9-381cb4f27255" />

