### PR TITLE
feat(email): add layout and styling to password reset email

### DIFF
--- a/src/lib/mail.ts
+++ b/src/lib/mail.ts
@@ -1,5 +1,5 @@
 // mail utility
-import nodemailer from 'nodemailer';
+import nodemailer from "nodemailer";
 
 export const transporter = nodemailer.createTransport({
   service: "gmail",
@@ -15,9 +15,71 @@ export async function sendPasswordResetEmail(to: string, resetUrl: string) {
     to,
     subject: "Reset your password",
     html: `
-      <p>You requested a password reset. Click the link below to create a new password:</p>
-      <a href="${resetUrl}">${resetUrl}</a>
-      <p>This link will expire in 15 minutes.</p>
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Password Reset</title>
+          <style>
+            @media only screen and (max-width: 600px) {
+              .container {
+                width: 100% !important;
+              }
+            }
+          </style>
+      </head>
+      <body style="margin:0; padding:0; background:#F2F8F9; font-family: "Helvetica", "Arial", sans-serif;">
+      <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+            <tr>
+              <td align="center" style="padding:20px 0;">
+                <table class="container" role="presentation" border="0" cellpadding="0" cellspacing="0" width="600" style="background:#ffffff; border-radius:8px; padding:30px; text-align:left;">
+                  
+                  <!-- Header -->
+                  <tr>
+                    <td style="text-align:center; padding-bottom:20px;">
+                      <h2 style="margin:0; color:#487E92;">HelpChain</h2>
+                    </td>
+                  </tr>
+
+                  <!-- Main content -->
+                  <tr>
+                    <td style="color:#333;">
+                      <p style="font-size:16px;">Hello,</p>
+                      <p style="font-size:16px;">You requested a password reset. Click the button below to create a new password. If you didn’t request this, you can safely ignore this email. The reset link will expire in 15 minutes.</p>
+                    </td>
+                  </tr>
+
+                  <!-- Reset link -->
+                  <tr>
+                    <td align="center" style="padding:20px 0;">
+                      <table role="presentation" border="0" cellspacing="0" cellpadding="0">
+                        <tr>
+                          <td style="background:#487E92; border-radius:4px;">
+                            <a href="${resetUrl}" style="display:inline-block; padding:12px 24px; color:#ffffff; text-decoration:none; font-size:16px; font-weight:bold;">
+                              Reset Password
+                            </a>
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+
+                  <!-- Footer -->
+                  <tr>
+                    <td style="color:#777; font-size:12px; text-align:center; padding-top:20px;">
+                      If the button doesn’t work, copy and paste this link into your browser:  
+                      <br />
+                      <a href="${resetUrl}" style="color:#004aad;">${resetUrl}</a>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+      </body>
+
+      </html>
     `,
   });
 }


### PR DESCRIPTION
### Checklist

- [ ] My code follows the project's coding standards
- [ ] I have reviewed my own code before submitting
- [ ] I updated documentation where necessary
- [ ] My changes do not introduce new warnings or errors

---

### Description
This PR adds layout and styling to the reset email. 

---

### Files Changed
- `src/lib/mail.ts`

---

### UI Changes / Screenshots (if applicable)
Initially:
<img width="1354" height="466" alt="Screenshot 2025-09-15 at 12 40 28" src="https://github.com/user-attachments/assets/16e4aca6-608d-4bc4-8250-587ab42654f7" />

Desktop now:
<img width="1345" height="634" alt="Screenshot 2025-09-15 at 13 06 42" src="https://github.com/user-attachments/assets/a174648c-5a61-46fd-a6b6-e2a53ad97155" />

Mobile now:
![photo_2025-09-15 13 24 22](https://github.com/user-attachments/assets/eff71cc0-af70-4df9-877a-1b531063dced)



---

### Documentation Updates

No changes made to the documentation.

---

### Tests

Tested manually in browsers on desktop and mobile.
